### PR TITLE
Validate websocket JSON to make sure the server does not crash upon receiving invalid jSON

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -369,8 +369,9 @@ router.get("/game", checkAuthentication(PAGE_ERROR_OUTPUT), function(req, res, n
 router.ws("/gameUpdate", checkAuthentication(SOCKET_ERROR_OUTPUT), function(ws, req, next) {
     console.log("Opening socket.");
     ws.on("message", function(message) {
+        var tempCommandList;
         try {
-            var tempCommandList = JSON.parse(message);
+            tempCommandList = JSON.parse(message);
         } catch (tempErr) {
             var tempResult = {
                 success: false,

--- a/routes/index.js
+++ b/routes/index.js
@@ -369,7 +369,16 @@ router.get("/game", checkAuthentication(PAGE_ERROR_OUTPUT), function(req, res, n
 router.ws("/gameUpdate", checkAuthentication(SOCKET_ERROR_OUTPUT), function(ws, req, next) {
     console.log("Opening socket.");
     ws.on("message", function(message) {
-        var tempCommandList = JSON.parse(message);
+        try {
+            var tempCommandList = JSON.parse(message);
+        } catch (tempErr) {
+            var tempResult = {
+                success: false,
+                message: "Invalid JSON",
+            };
+            ws.send(JSON.stringify(tempResult));
+            return;
+        }
         if (gameUtils.isInDevelopmentMode) {
             setTimeout(function() {
                 performUpdate(tempCommandList);


### PR DESCRIPTION
I accidentally sent invalid JSON to the server and it crashed. This fix wraps the parsing in a try-catch block to make sure the server handles invalid JSON properly and responds with an error message.

I have not been able to test the fix, but I see no reason for it not to work.

(Sorry for crashing the server, it wasn't my intention)