### PR TITLE
Update game.js

### DIFF
--- a/utils/game.js
+++ b/utils/game.js
@@ -499,7 +499,8 @@ function performGetAvatarChangesCommand(command, player, commandList) {
 }
 
 function performPlaceSymbolTileCommand(command, player, commandList) {
-    player.placeSymbolTile(command.tile);
+    if (typeof(command.tile) == "number")
+        player.placeSymbolTile(command.tile);
 }
 
 function performSetGuidelinePosCommand(command, player, commandList) {


### PR DESCRIPTION
So, on a project, I accidentally put a string in the addPlaceSymbolTile command, and that set the tile's value to be 0.
However, I actually request that you don't implement this and instead make it so that the holes can be filled in - the 0 tiles are the darkest tiles in the game.